### PR TITLE
Correction in SurfaceFlinger to update the Display config according t…

### DIFF
--- a/services/surfaceflinger/DisplayHardware/HWC2.h
+++ b/services/surfaceflinger/DisplayHardware/HWC2.h
@@ -35,6 +35,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <map>
 
 namespace android {
     class Fence;
@@ -352,7 +353,7 @@ private:
     bool mIsConnected;
     bool mIsVirtual;
     std::unordered_map<hwc2_layer_t, std::weak_ptr<Layer>> mLayers;
-    std::unordered_map<hwc2_config_t, std::shared_ptr<const Config>> mConfigs;
+    std::map<hwc2_config_t, std::shared_ptr<const Config>> mConfigs;
 };
 
 class Layer


### PR DESCRIPTION
…o index

Currently SF uses unordered_map to update DisplayConfig(mConfig)
which doesn't guarentee the order of the display config index;
made a change in SF to update configs according to the index value.

JIRA: https://01.org/jira/browse/AIA-403
Test: Able to set correct Display mode

Signed-off-by: N, Poornima Y <poornima.y.n@intel.com>